### PR TITLE
Fix code block ending

### DIFF
--- a/markdown.sh
+++ b/markdown.sh
@@ -227,7 +227,7 @@ b # else, branch to the end of the script
 x
 # look for the code items, if there wrap the pre-code tags
 /\t| {4}/{
-s/(\t| {4})(.*)/<pre><code>\1\2<\/code><\/pre>/ # wrap the ending tags
+s/(\t| {4})(.*)/<pre><code>\n\1\2\n<\/code><\/pre>/ # wrap the ending tags
 p
 b
 }


### PR DESCRIPTION
Fix `&lt;/code&gt;&lt;/pre&gt;` instead of `</code></pre>` on closing code block.
Also added new line on top to keep original formatting